### PR TITLE
Fix tests failing when port 8080 is busy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use actix_web::{dev::Server, get, web, App, HttpResponse, HttpServer, Responder};
+use std::net::TcpListener;
 
 #[get("/health_check")]
 async fn health_check() -> impl Responder {
@@ -15,14 +16,14 @@ async fn hello_world() -> impl Responder {
     "Hello World!"
 }
 
-pub fn run() -> Result<Server, std::io::Error> {
+pub fn run(listener: TcpListener) -> Result<Server, std::io::Error> {
     let server = HttpServer::new(|| {
         App::new()
             .service(health_check)
             .service(greet)
             .service(hello_world)
     })
-    .bind(("127.0.0.1", 8080))?
+    .listen(listener)?
     .run();
 
     Ok(server)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 pub mod lib;
+use std::net::TcpListener;
+
 use zero_to_prod::run;
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    run()?.await
+    let listener = TcpListener::bind("127.0.0.1:8080").expect("Failed to bind random port.");
+    run(listener)?.await
 }

--- a/tests/health_check.rs
+++ b/tests/health_check.rs
@@ -1,10 +1,12 @@
+use std::net::TcpListener;
+
 #[tokio::test]
 async fn test_health_check() {
-    spawn_app();
+    let address = spawn_app();
     let client = reqwest::Client::new();
 
     let response = client
-        .get("http://127.0.0.1:8080/health_check")
+        .get(&format!("{}/health_check", &address))
         .send()
         .await
         .expect("Failed to execute request.");
@@ -13,7 +15,11 @@ async fn test_health_check() {
     assert_eq!(Some(0), response.content_length());
 }
 
-fn spawn_app() {
-    let server = zero_to_prod::run().expect("Failed to bind address.");
+fn spawn_app() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind random port.");
+    let port = listener.local_addr().unwrap().port();
+    let server = zero_to_prod::run(listener).expect("Failed to bind address.");
     let _ = tokio::spawn(server);
+
+    format!("http://127.0.0.1:{}", port)
 }


### PR DESCRIPTION
Currently application has hardcoded ports. This is an issue, as when port 8080 (hardcoded value) is taken, tests fail.

This PR updates that by;

- Decoupling port binding & listening
- Adds capability to get system assigned port via asking for port 0
- Returning the application URL in test suite so that we can target it